### PR TITLE
Made the possibility to bind-mount /home/config to host

### DIFF
--- a/Build/Docker/amd64
+++ b/Build/Docker/amd64
@@ -6,6 +6,10 @@ WORKDIR /home
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl unzip sed chromium \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 RUN curl -L -k -o ffprobe.zip https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffprobe-6.1-linux-64.zip \
     && unzip -o ffprobe.zip && rm -f ffprobe.zip \
     && mv ffprobe /usr/bin/ffprobe && chmod +x /usr/bin/ffprobe
@@ -27,4 +31,6 @@ RUN mkdir -p torrserver && curl -L -k -o torrserver/TorrServer-linux https://git
 
 RUN echo '{"puppeteer":{"executablePath":"/usr/bin/chromium"}}' > init.conf
 
-ENTRYPOINT ["/usr/share/dotnet/dotnet", "Lampac.dll"]
+# Use docker-entrypoint script
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/bin/bash", "-c", "/usr/share/dotnet/dotnet Lampac.dll"]

--- a/Build/Docker/compose.yaml
+++ b/Build/Docker/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  lampac:
+    image: immisterio/lampac:latest
+    container_name: lampac
+	restart: unless-stopped
+    ports:
+      - 9118:9118
+    volumes:
+      - /Media:/home/dlna
+      - ./config:/home/config

--- a/Build/Docker/docker-entrypoint.sh
+++ b/Build/Docker/docker-entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+# Arrays for directories and files that need to be processed
+DIRS=("plugins" "module")
+FILES=("init.conf" "example.conf")
+
+# Check if we have write permissions in config directory
+if [ ! -w /home/config ]; then
+    exit 1
+fi
+
+# Create base config directory if it doesn't exist
+mkdir -p /home/config
+
+# Function to handle directory processing
+# Moves directory to config if doesn't exist and creates symlink
+handle_directory() {
+    local dir=$1
+
+    if [ ! -d "/home/config/$dir" ]; then
+        if ! mv "/home/$dir" /home/config/ 2>/dev/null; then
+            return 1
+        fi
+    fi
+
+    # Remove existing directory and create symlink
+    rm -rf "/home/$dir"
+    if ! ln -s "/home/config/$dir" /home; then
+        return 1
+    fi
+}
+
+# Function to handle file processing
+# Moves file to config if doesn't exist and creates symlink
+handle_file() {
+    local file=$1
+
+    if [ -f "/home/config/$file" ]; then
+        rm -f "/home/$file"
+    else
+        if ! mv "/home/$file" /home/config/ 2>/dev/null; then
+            return 1
+        fi
+    fi
+
+    # Create symlink for the file
+    if ! ln -sf "/home/config/$file" /home/; then
+        return 1
+    fi
+}
+
+# Process all directories
+for dir in "${DIRS[@]}"; do
+    if ! handle_directory "$dir"; then
+        exit 1
+    fi
+done
+
+# Process all files
+for file in "${FILES[@]}"; do
+    if ! handle_file "$file"; then
+        exit 1
+    fi
+done
+
+exec "$@"


### PR DESCRIPTION
Теперь перед запуском контейнера скрипт будет проверять наличие директории /home/config и ее поддиректорий. И если они не существуют, то перемещать туда директории "plugins" и "module", а также файлы "init.conf" и "example.conf". После чего скрипт создает симлинки на перемещенные директории и файлы и складывает их на привычные места.