### PR TITLE
Refactor SISI bookmarks to SQLite

### DIFF
--- a/Shared/Models/SQL/SisiContext.cs
+++ b/Shared/Models/SQL/SisiContext.cs
@@ -1,0 +1,59 @@
+using Microsoft.EntityFrameworkCore;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Shared.Models.SQL
+{
+    public class SisiContext : DbContext
+    {
+        public static void Configure()
+        {
+            try
+            {
+                Directory.CreateDirectory("database");
+
+                using (var context = new SisiContext())
+                    context.Database.EnsureCreated();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Sisi.sql initialization failed: {ex.Message}");
+            }
+        }
+
+        public DbSet<SisiBookmarkSqlModel> bookmarks { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (Startup.IsShutdown)
+                return;
+
+            optionsBuilder.UseSqlite("Data Source=database/Sisi.sql");
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<SisiBookmarkSqlModel>()
+                        .HasIndex(b => new { b.user, b.uid })
+                        .IsUnique();
+        }
+    }
+
+    public class SisiBookmarkSqlModel
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public long Id { get; set; }
+
+        [Required]
+        public string user { get; set; }
+
+        [Required]
+        public string uid { get; set; }
+
+        public DateTime created { get; set; }
+
+        [Required]
+        public string json { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `SisiContext` EF Core context to persist SISI bookmarks in SQLite
- rewrite `SISI/BookmarkController` to load, add and remove bookmarks through the new SQLite storage
- update application startup and migration code to initialize and populate the SQLite database while removing the old LiteDB collection and migrating existing `sisi_users` bookmarks into SQLite

## Testing
- `dotnet build Lampac.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d10c130a34832a9433ef07ab676f6c