### PR TITLE
Add streaming JSON readers for single-access mode

### DIFF
--- a/Online/Controllers/VDBmovies.cs
+++ b/Online/Controllers/VDBmovies.cs
@@ -9,7 +9,23 @@ namespace Online.Controllers
 {
     public class VDBmovies : BaseOnlineController
     {
-        public static List<MovieDB> database = null;
+        static List<MovieDB> databaseCache;
+
+        public static IEnumerable<MovieDB> database
+        {
+            get
+            {
+                if (AppInit.conf.multiaccess)
+                {
+                    return databaseCache ??= JsonHelper.ListReader<MovieDB>("data/cdnmovies.json", 105000);
+                }
+
+                if (databaseCache != null)
+                    databaseCache = null;
+
+                return JsonHelper.ItemReader<MovieDB>("data/cdnmovies.json");
+            }
+        }
 
         static string referer = CrypTo.DecodeBase64("aHR0cHM6Ly9tb3ZpZWJvb20uc3RvcmUv");
 
@@ -41,15 +57,14 @@ namespace Online.Controllers
                 if (!init.spider)
                     return OnError("spider");
 
-                if (database == null)
-                    database = JsonHelper.ListReader<MovieDB>("data/cdnmovies.json", 105000);
-
                 var stpl = new SimilarTpl();
+
+                var db = database;
 
                 string stitle = StringConvert.SearchName(title);
                 string sorigtitle = StringConvert.SearchName(original_title);
 
-                foreach (var j in database)
+                foreach (var j in db)
                 {
                     if (stpl.data.Count > 100)
                         break;

--- a/Online/Controllers/VeoVeo.cs
+++ b/Online/Controllers/VeoVeo.cs
@@ -136,7 +136,23 @@ namespace Online.Controllers
         #endregion
 
         #region search
-        public static List<Movie> database = JsonHelper.ListReader<Movie>("data/veoveo.json", 45000);
+        static List<Movie> databaseCache;
+
+        public static IEnumerable<Movie> database
+        {
+            get
+            {
+                if (AppInit.conf.multiaccess)
+                {
+                    return databaseCache ??= JsonHelper.ListReader<Movie>("data/veoveo.json", 45000);
+                }
+
+                if (databaseCache != null)
+                    databaseCache = null;
+
+                return JsonHelper.ItemReader<Movie>("data/veoveo.json");
+            }
+        }
 
         Movie? search(OnlinesSettings init, ProxyManager proxyManager, WebProxy proxy, string imdb_id, long kinopoisk_id, string title, string original_title)
         {

--- a/Online/OnlineApi.cs
+++ b/Online/OnlineApi.cs
@@ -212,12 +212,10 @@ namespace Online.Controllers
 
             async Task<string> getVSDN(string imdb)
             {
-                if (Lumex.database == null && AppInit.conf.Lumex.spider && AppInit.conf.mikrotik == false)
-                    Lumex.database = JsonHelper.ListReader<DatumDB>("data/lumex.json", 105000);
-
-                if (Lumex.database != null)
+                if (AppInit.conf.Lumex.spider && AppInit.conf.mikrotik == false)
                 {
-                    long? res = Lumex.database.FirstOrDefault(i => i.imdb_id == imdb).kinopoisk_id;
+                    var db = Lumex.database;
+                    long? res = db.FirstOrDefault(i => i.imdb_id == imdb).kinopoisk_id;
                     if (res > 0)
                         return res.ToString();
                 }

--- a/Shared/Engine/JsonHelper.cs
+++ b/Shared/Engine/JsonHelper.cs
@@ -1,5 +1,8 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
+using System.Collections;
+using System.Collections.Generic;
 using System.IO.Compression;
+using System.Linq;
 
 namespace Shared.Engine
 {
@@ -35,6 +38,96 @@ namespace Shared.Engine
             }
 
             return items;
+        }
+
+        public static IEnumerable<T> ItemReader<T>(string filePath)
+        {
+            if (!File.Exists(filePath))
+                return Enumerable.Empty<T>();
+
+            return new JsonItemEnumerable<T>(filePath);
+        }
+
+        private class JsonItemEnumerable<T> : IEnumerable<T>
+        {
+            readonly string filePath;
+
+            public JsonItemEnumerable(string filePath)
+            {
+                this.filePath = filePath;
+            }
+
+            public IEnumerator<T> GetEnumerator() => new JsonItemEnumerator(filePath);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            private class JsonItemEnumerator : IEnumerator<T>
+            {
+                readonly string filePath;
+                readonly JsonSerializer serializer = new JsonSerializer();
+
+                FileStream fileStream;
+                GZipStream gzipStream;
+                StreamReader reader;
+                JsonTextReader jsonReader;
+
+                public JsonItemEnumerator(string filePath)
+                {
+                    this.filePath = filePath;
+                    Initialize();
+                }
+
+                public T Current { get; private set; }
+
+                object IEnumerator.Current => Current;
+
+                void Initialize()
+                {
+                    try
+                    {
+                        fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        gzipStream = new GZipStream(fileStream, CompressionMode.Decompress);
+                        reader = new StreamReader(gzipStream);
+                        jsonReader = new JsonTextReader(reader);
+                    }
+                    catch
+                    {
+                        Dispose();
+                    }
+                }
+
+                public bool MoveNext()
+                {
+                    if (jsonReader == null)
+                        return false;
+
+                    while (jsonReader.Read())
+                    {
+                        if (jsonReader.TokenType == JsonToken.StartObject)
+                        {
+                            try
+                            {
+                                Current = serializer.Deserialize<T>(jsonReader);
+                                return true;
+                            }
+                            catch { }
+                        }
+                    }
+
+                    Current = default;
+                    return false;
+                }
+
+                public void Reset() => throw new NotSupportedException();
+
+                public void Dispose()
+                {
+                    jsonReader?.Close();
+                    reader?.Dispose();
+                    gzipStream?.Dispose();
+                    fileStream?.Dispose();
+                }
+            }
         }
     }
 }

--- a/Shared/Engine/Online/Lumex.cs
+++ b/Shared/Engine/Online/Lumex.cs
@@ -43,7 +43,7 @@ namespace Shared.Engine.Online
         #endregion
 
         #region Search
-        public async ValueTask<SimilarTpl> Search(string title, string original_title, int serial, int clarification, List<DatumDB> database = null)
+        public async ValueTask<SimilarTpl> Search(string title, string original_title, int serial, int clarification, IEnumerable<DatumDB> database = null)
         {
             if (string.IsNullOrWhiteSpace(title ?? original_title))
                 return default;
@@ -107,10 +107,11 @@ namespace Shared.Engine.Online
             else if (database != null)
             {
                 #region database
-                if (database == null)
-                    return default;
+                int capacity = 100;
+                if (database is ICollection<DatumDB> collection)
+                    capacity = collection.Count > 100 ? 100 : collection.Count;
 
-                var stpl = new SimilarTpl(database.Count > 100 ? 100 : database.Count);
+                var stpl = new SimilarTpl(capacity);
 
                 foreach (var item in database)
                 {


### PR DESCRIPTION
## Summary
- add a streaming JSON helper to avoid loading large data files into memory when multiaccess is disabled
- update VeoVeo, VDBmovies, and Lumex controllers to use the streamed readers and clear cached lists when appropriate
- adapt Lumex search logic and Online API integration to consume the new enumerable data source

## Testing
- dotnet build Lampac.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e14b364832ab9c9efeba9a33e8a