### PR TITLE
Fix script cache cleanup in CSharpEval

### DIFF
--- a/Shared/Engine/CSharpEval.cs
+++ b/Shared/Engine/CSharpEval.cs
@@ -52,15 +52,24 @@ namespace Shared.Engine
             {
                 var now = DateTime.UtcNow;
 
-                foreach (var entry in scripts.Select(i => new { i.Key, i.Value.IsValueCreated, i.Value.Value.Ex }).ToArray())
+                foreach (var pair in scripts.ToArray())
                 {
-                    if (!entry.IsValueCreated)
+                    var lazy = pair.Value;
+
+                    if (!lazy.IsValueCreated)
                         continue;
+
+                    var entry = lazy.Value;
+                    if (entry == null)
+                    {
+                        scripts.TryRemove(pair.Key, out _);
+                        continue;
+                    }
 
                     if (now <= entry.Ex)
                         continue;
 
-                    scripts.TryRemove(entry.Key, out _);
+                    scripts.TryRemove(pair.Key, out _);
                 }
             }
             catch { }


### PR DESCRIPTION
## Summary
- update the ClearScripts method to avoid creating new lazy values while evaluating expiration
- ensure stale entries are safely removed when they have already been instantiated

## Testing
- dotnet build Lampac.sln *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_68d427546bf0832a86a4b2205c4e1f6c