### PR TITLE
Add configurable GC settings

### DIFF
--- a/Lampac/Program.cs
+++ b/Lampac/Program.cs
@@ -90,6 +90,22 @@ namespace Lampac
             CultureInfo.CurrentCulture = new CultureInfo("ru-RU");
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
+            var gc = AppInit.conf.GC;
+            if (gc != null && gc.enable)
+            {
+                if (gc.Concurrent.HasValue)
+                    AppContext.SetSwitch("System.GC.Concurrent", gc.Concurrent.Value);
+
+                if (gc.ConserveMemory.HasValue)
+                    AppContext.SetData("System.GC.ConserveMemory", gc.ConserveMemory.Value);
+
+                if (gc.HighMemoryPercent.HasValue)
+                    AppContext.SetData("System.GC.HighMemoryPercent", gc.HighMemoryPercent.Value);
+
+                if (gc.RetainVM.HasValue)
+                    AppContext.SetSwitch("System.GC.RetainVM", gc.RetainVM.Value);
+            }
+
             Http.onlog += (e, log) =>
             {
                 soks.SendLog(log, "http");

--- a/Shared/AppInit.cs
+++ b/Shared/AppInit.cs
@@ -341,8 +341,10 @@ namespace Shared
 
         public StorageConf storage = new StorageConf() { enable = true, max_size = 7_000000, brotli = false, md5name = true };
 
-        public PuppeteerConf chromium = new PuppeteerConf() 
-        { 
+        public GCConf GC { get; set; } = new GCConf();
+
+        public PuppeteerConf chromium = new PuppeteerConf()
+        {
             enable = true, Headless = true,
             Args = ["--disable-blink-features=AutomationControlled"], // , "--window-position=-2000,100"
             context = new KeepopenContext() { keepopen = true, keepalive = 20, min = 0, max = 4 }

--- a/Shared/Models/AppConf/GCConf.cs
+++ b/Shared/Models/AppConf/GCConf.cs
@@ -1,0 +1,15 @@
+namespace Shared.Models.AppConf
+{
+    public class GCConf
+    {
+        public bool enable { get; set; } = true;
+
+        public bool? Concurrent { get; set; } = false;
+
+        public int? ConserveMemory { get; set; } = 9;
+
+        public int? HighMemoryPercent { get; set; } = 1;
+
+        public bool? RetainVM { get; set; } = false;
+    }
+}


### PR DESCRIPTION
## Summary
- add a GC configuration section that defaults to enabling tuned settings
- apply the configured GC switches and values during application startup

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d55b57e784832ab8a695d2ad96b89b