### PR TITLE
Refine Kodik offline fallback initialization

### DIFF
--- a/Online/Controllers/Anime/Kodik.cs
+++ b/Online/Controllers/Anime/Kodik.cs
@@ -39,7 +39,7 @@ namespace Online.Controllers
                 init.hls,
                 init.cdn_is_working,
                 "video",
-                () => database,
+                database,
                 (uri, head) => Http.Get(init.cors(uri), timeoutSeconds: 8, proxy: proxy, headers: httpHeaders(init)),
                 (uri, data) => Http.Post(init.cors(uri), data, timeoutSeconds: 8, proxy: proxy, headers: httpHeaders(init)),
                 streamfile => HostStreamProxy(init, streamfile, proxy: proxy),

--- a/Online/Controllers/Anime/Kodik.cs
+++ b/Online/Controllers/Anime/Kodik.cs
@@ -11,6 +11,21 @@ namespace Online.Controllers
     {
         ProxyManager proxyManager = new ProxyManager(AppInit.conf.Kodik);
 
+        #region database
+        static List<Result> databaseCache;
+
+        static IEnumerable<Result> database
+        {
+            get
+            {
+                if (AppInit.conf.multiaccess || databaseCache != null)
+                    return databaseCache ??= JsonHelper.ListReader<Result>("data/kodik.json", 105000);
+
+                return JsonHelper.IEnumerableReader<Result>("data/kodik.json");
+            }
+        }
+        #endregion
+
         #region InitKodikInvoke
         public KodikInvoke InitKodikInvoke(KodikSettings init)
         {
@@ -24,6 +39,7 @@ namespace Online.Controllers
                 init.hls,
                 init.cdn_is_working,
                 "video",
+                () => database,
                 (uri, head) => Http.Get(init.cors(uri), timeoutSeconds: 8, proxy: proxy, headers: httpHeaders(init)),
                 (uri, data) => Http.Post(init.cors(uri), data, timeoutSeconds: 8, proxy: proxy, headers: httpHeaders(init)),
                 streamfile => HostStreamProxy(init, streamfile, proxy: proxy),

--- a/Online/Controllers/Anime/Kodik.cs
+++ b/Online/Controllers/Anime/Kodik.cs
@@ -122,7 +122,7 @@ namespace Online.Controllers
                     return LocalRedirect(accsArgs($"/lite/kodik?rjson={rjson}&title={HttpUtility.UrlEncode(title)}&original_title={HttpUtility.UrlEncode(original_title)}"));
             }
 
-            return ContentTo(oninvk.Html(content, accsArgs(string.Empty), imdb_id, kinopoisk_id, title, original_title, clarification, pick, kid, s, true, rjson));
+            return ContentTo(await oninvk.Html(content, accsArgs(string.Empty), imdb_id, kinopoisk_id, title, original_title, clarification, pick, kid, s, true, rjson));
         }
 
         #region Video

--- a/Shared/Engine/Online/Kodik.cs
+++ b/Shared/Engine/Online/Kodik.cs
@@ -1,4 +1,5 @@
 ﻿using Shared.Models;
+using Shared.Engine;
 using Shared.Models.Base;
 using Shared.Models.Online.Kodik;
 using Shared.Models.Templates;
@@ -166,10 +167,13 @@ namespace Shared.Engine.Online
             if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(target))
                 return false;
 
-            if (string.Equals(source, target, StringComparison.OrdinalIgnoreCase))
-                return true;
+            string normalizedSource = StringConvert.SearchName(source);
+            string normalizedTarget = StringConvert.SearchName(target);
 
-            return source.IndexOf(target, StringComparison.OrdinalIgnoreCase) >= 0;
+            if (string.IsNullOrWhiteSpace(normalizedSource) || string.IsNullOrWhiteSpace(normalizedTarget))
+                return false;
+
+            return normalizedSource.Contains(normalizedTarget);
         }
         #endregion
 

--- a/Shared/Models/Online/Kodik/Result.cs
+++ b/Shared/Models/Online/Kodik/Result.cs
@@ -14,6 +14,10 @@
 
         public string link { get; set; }
 
+        public string imdb_id { get; set; }
+
+        public long kinopoisk_id { get; set; }
+
         public Translation translation { get; set; }
 
         public int last_season { get; set; }


### PR DESCRIPTION
## Summary
- cache the offline Kodik database inside the controller and pass it into KodikInvoke
- update KodikInvoke to consume a provided data source instead of loading files directly
- return fallback Kodik results as an IEnumerable to avoid loading the full dataset and adjust title matching to iterate the source only once

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d809a01e60832abb10ac19cab86f48