### PR TITLE
Add percentile averages to response time stats

### DIFF
--- a/Lampac/Controllers/OpenStatController.cs
+++ b/Lampac/Controllers/OpenStatController.cs
@@ -5,7 +5,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
 using System;
+using System.Collections.Generic;
 using System.Net.NetworkInformation;
+using System.Linq;
 using Shared.Models.AppConf;
 using Shared.PlaywrightCore;
 using Shared.Engine;
@@ -75,6 +77,14 @@ namespace Lampac.Controllers
 
             var responseStats = RequestStatisticsTracker.GetResponseTimeStatsLastMinute();
 
+            var httpResponseMs = new Dictionary<string, object>
+            {
+                ["avg"] = Math.Round(responseStats.Average, 2)
+            };
+
+            foreach (var percentile in responseStats.PercentileAverages.OrderBy(x => x.Key))
+                httpResponseMs[percentile.Key.ToString()] = Math.Round(percentile.Value, 2);
+
             return Json(new
             {
                 req_min,
@@ -82,12 +92,7 @@ namespace Lampac.Controllers
                 nws_online = nws.ConnectionCount,
                 soks_online = soks.connections,
                 http_active = RequestStatisticsTracker.ActiveHttpRequests,
-                http_response_ms = new
-                {
-                    avg = Math.Round(responseStats.avg, 2),
-                    min = Math.Round(responseStats.min, 2),
-                    max = Math.Round(responseStats.max, 2)
-                },
+                http_response_ms = httpResponseMs,
                 tcpConnections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections().Length
             });
         }


### PR DESCRIPTION
## Summary
- calculate decile-based averages for tracked HTTP response times
- expose the percentile averages in the /stats/request endpoint response

## Testing
- dotnet build Lampac.sln *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dec2a5edd4832abe81b239bc90f958